### PR TITLE
Create RNBackgroundFetch.android.js

### DIFF
--- a/RNBackgroundFetch.android.js
+++ b/RNBackgroundFetch.android.js
@@ -1,0 +1,9 @@
+var API = {
+  configure: () => {},
+  start: () => {},
+  stop: () => {},
+  finish: () => {}
+};
+
+
+module.exports = API;


### PR DESCRIPTION
Just a no-ops API, so the `backgroundFetch` code is ignored on android.
