### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-fetch",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "iOS BackgroundFetch API implementation for React Native",
   "main": "RNBackgroundFetch.ios.js",
   "scripts": {


### PR DESCRIPTION
to prevent pre 0.40.0 version of react-native-background-geolocation (which requires `~1.0.0`) from loading the post 0.40.0 version of *this* plugin