### PR TITLE
automate manual installation steps with rnpm postlink hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,22 @@
   "bugs": {
     "url": "https://github.com/transistorsoft/react-native-background-fetch/issues"
   },
+  "rnpm": {
+    "commands": {
+      "postlink": "node_modules/react-native-background-fetch/scripts/postlink.js",
+      "postunlink": "node_modules/react-native-background-fetch/scripts/postunlink.js"
+    }
+  },
   "homepage": "https://transistorsoft.github.io/react-native-background-fetch",
   "peerDependencies": {
     "react-native": ">=0.28.0"
   },
   "devDependencies": {
     "react-native": "^0.40.0"
+  },
+  "dependencies": {
+    "fast-plist": "^0.1.2",
+    "plist": "^2.0.1",
+    "xcode": "^0.9.1"
   }
 }

--- a/scripts/postlink.js
+++ b/scripts/postlink.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const fs = require('fs');
+const xcode = require('xcode');
+const helpers = require('./xcode-helpers');
+
+const projectDirectory = process.cwd();
+const moduleDirectory = path.resolve(__dirname, '..');
+const packageManifest = require(projectDirectory + '/package.json');
+
+const projectConfig = {
+    sourceDir: path.join(projectDirectory, 'ios'),
+    pbxprojPath: path.join(
+        projectDirectory,
+        'ios',
+        packageManifest.name + '.xcodeproj',
+        'project.pbxproj'
+    )
+};
+
+const pathToFramework = path.relative(
+    projectConfig.sourceDir,
+    path.join(
+        moduleDirectory,
+        'ios',
+        'RNBackgroundFetch',
+        'TSBackgroundFetch.framework'
+    )
+);
+const pathToAppdelegateExtension = path.relative(
+    projectConfig.sourceDir,
+    path.join(
+        moduleDirectory,
+        'ios',
+        'RNBackgroundFetch',
+        'RNBackgroundFetch+AppDelegate.m'
+    )
+);
+
+const project = xcode.project(projectConfig.pbxprojPath).parseSync();
+// hacky, but the implementation of the productName getter reads only the first
+// project name, which for RN projects usually is "$(TARGET_NAME)".
+// There are a few issues and PRs at the xcode project open, but it seems a bit
+// stale.
+project.productName = packageManifest.name;
+
+const firstTarget = project.getFirstTarget();
+
+// addFramework crashes when it can't find a group named "Frameworks"
+if (!project.pbxGroupByName('Frameworks')) {
+    project.addPbxGroup([], 'Frameworks');
+}
+project.addFramework(pathToFramework, {
+    customFramework: true,
+    target: firstTarget.uuid
+});
+
+// extends the projects AppDelegate.m with our completion handler
+const projectGroup = project.findPBXGroupKey({ name: packageManifest.name });
+project.addSourceFile(pathToAppdelegateExtension, {}, projectGroup);
+
+// enable BackgroundModes and add "fetch" as mode
+project.addTargetAttribute('SystemCapabilities', {
+    'com.apple.BackgroundModes': { enabled: true }
+});
+const plist = helpers.readPlist(projectConfig.sourceDir, project);
+plist.UIBackgroundModes = ['fetch'];
+
+helpers.writePlist(projectConfig.sourceDir, project, plist);
+fs.writeFileSync(projectConfig.pbxprojPath, project.writeSync());

--- a/scripts/postlink.js
+++ b/scripts/postlink.js
@@ -61,10 +61,10 @@ if (!project.hasFile(file.path)) {
 helpers.addToFrameworkSearchPaths(
     project,
     '$(PROJECT_DIR)/' +
-        path.relative(
-            projectConfig.sourceDir,
-            path.join(moduleDirectory, 'ios')
-        ),
+    path.relative(
+        projectConfig.sourceDir,
+        path.join(moduleDirectory, 'ios')
+    ),
     true
 );
 
@@ -78,16 +78,19 @@ project.addSourceFile(
 
 // enable BackgroundModes and add "fetch" as a mode to plist file
 const targetAttributes = helpers.getTargetAttributes(project);
-project.addTargetAttribute(
-    'SystemCapabilities',
-    Object.assign({}, targetAttributes, {
-        'com.apple.BackgroundModes': Object.assign(
-            {},
-            targetAttributes['com.apple.BackgroundModes'] || {},
-            { enabled: true }
-        ),
-    })
-);
+
+const systemCapabilities = Object.assign({}, (targetAttributes.SystemCapabilities || {}), {
+    'com.apple.BackgroundModes': Object.assign(
+        {},
+        targetAttributes['com.apple.BackgroundModes'] || {},
+        { enabled: true }
+    ),
+});
+if (targetAttributes.SystemCapabilities) {
+    targetAttributes.SystemCapabilities = systemCapabilities;
+} else {
+    project.addTargetAttribute('SystemCapabilities', systemCapabilities);
+}
 const plist = helpers.readPlist(projectConfig.sourceDir, project);
 const UIBackgroundModes = plist.UIBackgroundModes || [];
 if (UIBackgroundModes.indexOf('fetch') === -1) {

--- a/scripts/postlink.js
+++ b/scripts/postlink.js
@@ -17,7 +17,7 @@ const projectConfig = {
         'ios',
         packageManifest.name + '.xcodeproj',
         'project.pbxproj'
-    )
+    ),
 };
 
 const pathToFramework = path.relative(
@@ -60,30 +60,34 @@ if (!project.hasFile(file.path)) {
 
 helpers.addToFrameworkSearchPaths(
     project,
-    '$(PROJECT_DIR)/' + path.relative(
-        projectConfig.sourceDir,
-        path.join(moduleDirectory, 'ios')
-    ),
+    '$(PROJECT_DIR)/' +
+        path.relative(
+            projectConfig.sourceDir,
+            path.join(moduleDirectory, 'ios')
+        ),
     true
 );
 
 // extends the projects AppDelegate.m with our completion handler
 const projectGroup = project.findPBXGroupKey({ name: packageManifest.name });
-project.addSourceFile(pathToAppdelegateExtension, {}, projectGroup);
+project.addSourceFile(
+    pathToAppdelegateExtension,
+    { target: project.getFirstTarget().uuid },
+    projectGroup
+);
 
 // enable BackgroundModes and add "fetch" as a mode to plist file
 const targetAttributes = helpers.getTargetAttributes(project);
-project.addTargetAttribute('SystemCapabilities', Object.assign(
-    {},
-    targetAttributes,
-    {
+project.addTargetAttribute(
+    'SystemCapabilities',
+    Object.assign({}, targetAttributes, {
         'com.apple.BackgroundModes': Object.assign(
             {},
-            (targetAttributes['com.apple.BackgroundModes'] || {}),
+            targetAttributes['com.apple.BackgroundModes'] || {},
             { enabled: true }
-        )
-    }
-));
+        ),
+    })
+);
 const plist = helpers.readPlist(projectConfig.sourceDir, project);
 const UIBackgroundModes = plist.UIBackgroundModes || [];
 if (UIBackgroundModes.indexOf('fetch') === -1) {

--- a/scripts/postunlink.js
+++ b/scripts/postunlink.js
@@ -17,7 +17,7 @@ const projectConfig = {
         'ios',
         packageManifest.name + '.xcodeproj',
         'project.pbxproj'
-    )
+    ),
 };
 
 const pathToFramework = path.relative(
@@ -51,18 +51,24 @@ project.removeFromPbxFrameworksBuildPhase(file);
 
 helpers.removeFromFrameworkSearchPaths(
     project,
-    '$(PROJECT_DIR)/' + path.relative(
-        projectConfig.sourceDir,
-        path.join(moduleDirectory, 'ios')
-    )
+    '$(PROJECT_DIR)/' +
+        path.relative(
+            projectConfig.sourceDir,
+            path.join(moduleDirectory, 'ios')
+        )
 );
 
 // remove AppDelegate extension
 const projectGroup = project.findPBXGroupKey({ name: packageManifest.name });
-project.removeSourceFile(pathToAppdelegateExtension, {}, projectGroup);
+project.removeSourceFile(
+    pathToAppdelegateExtension,
+    { target: project.getFirstTarget().uuid },
+    projectGroup
+);
 
 // disable BackgroundModes and remove "fetch" mode from plist file
-const targetAttributes = helpers.getTargetAttributes(project).SystemCapabilities;
+const targetAttributes = helpers.getTargetAttributes(project)
+    .SystemCapabilities;
 delete targetAttributes['com.apple.BackgroundModes'].enabled;
 if (Object.keys(targetAttributes['com.apple.BackgroundModes']).length === 0) {
     delete targetAttributes['com.apple.BackgroundModes'];
@@ -73,7 +79,9 @@ if (Object.keys(targetAttributes).length === 0) {
 }
 
 const plist = helpers.readPlist(projectConfig.sourceDir, project);
-plist.UIBackgroundModes = plist.UIBackgroundModes.filter(mode => mode !== 'fetch');
+plist.UIBackgroundModes = plist.UIBackgroundModes.filter(
+    mode => mode !== 'fetch'
+);
 if (plist.UIBackgroundModes.length === 0) {
     delete plist.UIBackgroundModes;
 }

--- a/scripts/postunlink.js
+++ b/scripts/postunlink.js
@@ -46,16 +46,18 @@ file.target = project.getFirstTarget().uuid;
 
 project.removeFromPbxBuildFileSection(file);
 project.removeFromPbxFileReferenceSection(file);
-project.removeFromFrameworksPbxGroup(file);
+if (project.pbxGroupByName('Frameworks')) {
+    project.removeFromFrameworksPbxGroup(file);
+}
 project.removeFromPbxFrameworksBuildPhase(file);
 
 helpers.removeFromFrameworkSearchPaths(
     project,
     '$(PROJECT_DIR)/' +
-        path.relative(
-            projectConfig.sourceDir,
-            path.join(moduleDirectory, 'ios')
-        )
+    path.relative(
+        projectConfig.sourceDir,
+        path.join(moduleDirectory, 'ios')
+    )
 );
 
 // remove AppDelegate extension
@@ -67,23 +69,26 @@ project.removeSourceFile(
 );
 
 // disable BackgroundModes and remove "fetch" mode from plist file
-const targetAttributes = helpers.getTargetAttributes(project)
-    .SystemCapabilities;
-delete targetAttributes['com.apple.BackgroundModes'].enabled;
-if (Object.keys(targetAttributes['com.apple.BackgroundModes']).length === 0) {
-    delete targetAttributes['com.apple.BackgroundModes'];
-}
-project.addTargetAttribute('SystemCapabilities', targetAttributes);
-if (Object.keys(targetAttributes).length === 0) {
-    project.removeTargetAttribute('SystemCapabilities');
+const systemCapabilities = helpers.getTargetAttributes(project).SystemCapabilities;
+if (systemCapabilities && systemCapabilities['com.apple.BackgroundModes']) {
+    delete systemCapabilities['com.apple.BackgroundModes'].enabled;
+    if (Object.keys(systemCapabilities['com.apple.BackgroundModes']).length === 0) {
+        delete systemCapabilities['com.apple.BackgroundModes'];
+    }
+
+    if (Object.keys(systemCapabilities).length === 0) {
+        project.removeTargetAttribute('SystemCapabilities');
+    }
 }
 
 const plist = helpers.readPlist(projectConfig.sourceDir, project);
-plist.UIBackgroundModes = plist.UIBackgroundModes.filter(
-    mode => mode !== 'fetch'
-);
-if (plist.UIBackgroundModes.length === 0) {
-    delete plist.UIBackgroundModes;
+if (Array.isArray(plist.UIBackgroundModes)) {
+    plist.UIBackgroundModes = plist.UIBackgroundModes.filter(
+        mode => mode !== 'fetch'
+    );
+    if (plist.UIBackgroundModes.length === 0) {
+        delete plist.UIBackgroundModes;
+    }
 }
 
 helpers.writePlist(projectConfig.sourceDir, project, plist);

--- a/scripts/postunlink.js
+++ b/scripts/postunlink.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const fs = require('fs');
+const xcode = require('xcode');
+const helpers = require('./xcode-helpers');
+
+const projectDirectory = process.cwd();
+const moduleDirectory = path.resolve(__dirname, '..');
+const packageManifest = require(projectDirectory + '/package.json');
+
+const projectConfig = {
+    sourceDir: path.join(projectDirectory, 'ios'),
+    pbxprojPath: path.join(
+        projectDirectory,
+        'ios',
+        packageManifest.name + '.xcodeproj',
+        'project.pbxproj'
+    )
+};
+
+const pathToFramework = path.relative(
+    projectConfig.sourceDir,
+    path.join(
+        moduleDirectory,
+        'ios',
+        'RNBackgroundFetch',
+        'TSBackgroundFetch.framework'
+    )
+);
+const pathToAppdelegateExtension = path.relative(
+    projectConfig.sourceDir,
+    path.join(
+        moduleDirectory,
+        'ios',
+        'RNBackgroundFetch',
+        'RNBackgroundFetch+AppDelegate.m'
+    )
+);
+
+const project = xcode.project(projectConfig.pbxprojPath).parseSync();
+// hacky, but the implementation of the productName getter reads only the first
+// project name, which for RN projects usually is "$(TARGET_NAME)".
+// There are a few issues and PRs at the xcode project open, but it seems a bit
+// stale.
+project.productName = packageManifest.name;
+
+const firstTarget = project.getFirstTarget();
+
+project.removeFramework(pathToFramework, {
+    customFramework: true,
+    target: firstTarget.uuid
+});
+
+// extends the projects AppDelegate.m with our completion handler
+const projectGroup = project.findPBXGroupKey({ name: packageManifest.name });
+project.removeSourceFile(pathToAppdelegateExtension, {}, projectGroup);
+
+// enable BackgroundModes and add "fetch" as mode
+project.removeTargetAttribute('SystemCapabilities');
+const plist = helpers.readPlist(projectConfig.sourceDir, project);
+delete plist.UIBackgroundModes;
+helpers.writePlist(projectConfig.sourceDir, project, plist);
+fs.writeFileSync(projectConfig.pbxprojPath, project.writeSync());

--- a/scripts/xcode-helpers.js
+++ b/scripts/xcode-helpers.js
@@ -68,6 +68,8 @@ function eachBuildConfiguration(project, predicate, callback) {
         .forEach(ref => callback(config[ref]));
 }
 
+// this is being used to determine whether the current target is a react-native
+// project: https://github.com/facebook/react-native/blob/545072b/local-cli/link/ios/mapHeaderSearchPaths.js#L31
 function hasLCPlusPlus(config) {
     return (config.buildSettings.OTHER_LDFLAGS || []).indexOf('"-lc++"') >= 0;
 }
@@ -109,6 +111,8 @@ function removeFromFrameworkSearchPaths(project, path) {
     });
 }
 
+// The node-xcode library doesn't offer a method to get all target attributes,
+// so we'll have to implement it ourselves.
 function getTargetAttributes(project, target) {
     var attributes = project.getFirstProject()['firstProject']['attributes'];
     target = target || project.getFirstTarget();

--- a/scripts/xcode-helpers.js
+++ b/scripts/xcode-helpers.js
@@ -76,6 +76,8 @@ function addToFrameworkSearchPaths(project, path, recursive) {
     eachBuildConfiguration(project, hasLCPlusPlus, config => {
         if (!config.buildSettings.FRAMEWORK_SEARCH_PATHS) {
             config.buildSettings.FRAMEWORK_SEARCH_PATHS = [];
+        } else if (typeof config.buildSettings.FRAMEWORK_SEARCH_PATHS === 'string') {
+            config.buildSettings.FRAMEWORK_SEARCH_PATHS = [config.buildSettings.FRAMEWORK_SEARCH_PATHS];
         }
         const fullPath = '"' + path + (recursive ? '/**' : '') + '"';
 
@@ -93,6 +95,8 @@ function removeFromFrameworkSearchPaths(project, path) {
     eachBuildConfiguration(project, hasLCPlusPlus, config => {
         if (!config.buildSettings.FRAMEWORK_SEARCH_PATHS) {
             config.buildSettings.FRAMEWORK_SEARCH_PATHS = [];
+        } else if (typeof config.buildSettings.FRAMEWORK_SEARCH_PATHS === 'string') {
+            config.buildSettings.FRAMEWORK_SEARCH_PATHS = [config.buildSettings.FRAMEWORK_SEARCH_PATHS];
         }
 
         const fullPath = unquote(path) + '/**';

--- a/scripts/xcode-helpers.js
+++ b/scripts/xcode-helpers.js
@@ -1,0 +1,66 @@
+const path = require('path');
+const fs = require('fs');
+// unfortunately we can't use the 'plist' module at the moment for parsing
+// because it has a few issues with empty strings and keys.
+// There are several issues and PRs on that repository open though and hopefully
+// we can revert back to only using one module once they're merged.
+const plistParser = require('fast-plist');
+const plistWriter = require('plist');
+
+// The getBuildProperty method of the 'xcode' project is a bit naive in that it
+// doesn't take a specific target but iterates over all of them and doesn't have
+// an exit condition if a property has been found.
+// Which in the case of react-native projects usually is the tvOS target because
+// it comes last.
+function getBuildProperty(project, property) {
+    const firstTarget = project.getFirstTarget().firstTarget;
+    const configurationList = project.pbxXCConfigurationList()[
+        firstTarget.buildConfigurationList
+    ];
+    const defaultBuildConfiguration = configurationList.buildConfigurations.reduce(
+        (acc, config) => {
+            const buildSection = project.pbxXCBuildConfigurationSection()[
+                config.value
+            ];
+            return buildSection.name ===
+                configurationList.defaultConfigurationName
+                ? buildSection
+                : acc;
+        }
+    );
+
+    return defaultBuildConfiguration.buildSettings[property];
+}
+
+function getPlistPath(sourceDir, project) {
+    const plistFile = getBuildProperty(project, 'INFOPLIST_FILE');
+    if (!plistFile) {
+        return null;
+    }
+    return path.join(
+        sourceDir,
+        plistFile.replace(/"/g, '').replace('$(SRCROOT)', '')
+    );
+}
+
+function readPlist(sourceDir, project) {
+    const plistPath = getPlistPath(sourceDir, project);
+    if (!plistPath || !fs.existsSync(plistPath)) {
+        return null;
+    }
+    return plistParser.parse(fs.readFileSync(plistPath, 'utf-8'));
+}
+
+function writePlist(sourceDir, project, plist) {
+    fs.writeFileSync(
+        getPlistPath(sourceDir, project),
+        plistWriter.build(plist)
+    );
+}
+
+module.exports = {
+    getBuildProperty: getBuildProperty,
+    getPlistPath: getPlistPath,
+    readPlist: readPlist,
+    writePlist: writePlist
+};


### PR DESCRIPTION
This commit adds two scripts `scripts/postlink.js` and
`scripts/postunlink.js` that are being executed by `rnpm link` /
`react-native link` during their lifecycle.
These scripts make use of the `xcode` and `plist` modules to automate
the remaining manual steps outlined here: https://github.com/transistorsoft/react-native-background-fetch/blob/master/docs/INSTALL-RNPM.md