### PR TITLE
Implement new RN 0.49 requiresMainQueueSetup method

### DIFF
--- a/ios/RNBackgroundFetch/RNBackgroundFetch.m
+++ b/ios/RNBackgroundFetch/RNBackgroundFetch.m
@@ -34,6 +34,11 @@ RCT_EXPORT_MODULE();
     return self;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (NSArray<NSString *> *)supportedEvents {
     return @[EVENT_FETCH];
 }

--- a/ios/RNBackgroundFetch/RNBackgroundFetch.m
+++ b/ios/RNBackgroundFetch/RNBackgroundFetch.m
@@ -36,7 +36,7 @@ RCT_EXPORT_MODULE();
 
 + (BOOL)requiresMainQueueSetup
 {
-    return YES;
+    return NO;
 }
 
 - (NSArray<NSString *> *)supportedEvents {


### PR DESCRIPTION
This prevents the following warning when using React Native v0.49+:

```
Module RNBackgroundFetch requires main queue setup since it overrides `init` but doesn't
implement `requiresMainQueueSetup. In a future release React Native will default to
initializing all native modules on a background thread unless explicitly opted-out of.
```