### PR TITLE
Find iOS project when the filename doesn't match project name

### DIFF
--- a/scripts/postlink.js
+++ b/scripts/postlink.js
@@ -8,16 +8,26 @@ const helpers = require('./xcode-helpers');
 
 const projectDirectory = process.cwd();
 const moduleDirectory = path.resolve(__dirname, '..');
+const sourceDirectory = path.join(projectDirectory, 'ios');
 const packageManifest = require(projectDirectory + '/package.json');
 
+function findPbxprojFile( directory ) {
+    const files = fs.readdirSync(directory);
+    for (let i = files.length - 1; i >= 0; i--) {
+        const fileName = files[i];
+        const ext = path.extname(fileName);
+
+        if (ext === '.xcodeproj') {
+            return path.join(directory, fileName, 'project.pbxproj');
+        }
+    }
+
+    return null;
+}
+
 const projectConfig = {
-    sourceDir: path.join(projectDirectory, 'ios'),
-    pbxprojPath: path.join(
-        projectDirectory,
-        'ios',
-        packageManifest.name + '.xcodeproj',
-        'project.pbxproj'
-    ),
+    sourceDir: sourceDirectory,
+    pbxprojPath: findPbxprojFile( sourceDirectory )
 };
 
 const pathToFramework = path.relative(

--- a/scripts/postunlink.js
+++ b/scripts/postunlink.js
@@ -8,16 +8,26 @@ const helpers = require('./xcode-helpers');
 
 const projectDirectory = process.cwd();
 const moduleDirectory = path.resolve(__dirname, '..');
+const sourceDirectory = path.join(projectDirectory, 'ios');
 const packageManifest = require(projectDirectory + '/package.json');
 
+function findPbxprojFile( directory ) {
+    const files = fs.readdirSync(directory);
+    for (let i = files.length - 1; i >= 0; i--) {
+        const fileName = files[i];
+        const ext = path.extname(fileName);
+
+        if (ext === '.xcodeproj') {
+            return path.join(directory, fileName, 'project.pbxproj');
+        }
+    }
+
+    return null;
+}
+
 const projectConfig = {
-    sourceDir: path.join(projectDirectory, 'ios'),
-    pbxprojPath: path.join(
-        projectDirectory,
-        'ios',
-        packageManifest.name + '.xcodeproj',
-        'project.pbxproj'
-    ),
+    sourceDir: sourceDirectory,
+    pbxprojPath: findPbxprojFile( sourceDirectory )
 };
 
 const pathToFramework = path.relative(


### PR DESCRIPTION
Fixes #63: finds the iOS .xcodeproj file even when the filename is different from package.json project name. This uses the same technique (and the same function with minor modifications) as the react-native cli tool. It assumes that there's only one project in the ios directory so it scans the directory and picks the first .xcodeproj file it finds.