### PR TITLE
Issue #63 Fix link error when iOS and npm project name are different

### DIFF
--- a/scripts/postlink.js
+++ b/scripts/postlink.js
@@ -8,14 +8,15 @@ const helpers = require('./xcode-helpers');
 
 const projectDirectory = process.cwd();
 const moduleDirectory = path.resolve(__dirname, '..');
-const packageManifest = require(projectDirectory + '/package.json');
+const sourceDirectory = path.join(projectDirectory, 'ios');
+const xcodeProjectDirectory = helpers.findProject(sourceDirectory);
 
 const projectConfig = {
-    sourceDir: path.join(projectDirectory, 'ios'),
+    sourceDir: sourceDirectory,
     pbxprojPath: path.join(
         projectDirectory,
         'ios',
-        packageManifest.name + '.xcodeproj',
+        xcodeProjectDirectory,
         'project.pbxproj'
     ),
 };
@@ -91,7 +92,8 @@ helpers.addToFrameworkSearchPaths(
 );
 
 // extends the projects AppDelegate.m with our completion handler
-const projectGroup = project.findPBXGroupKey({ name: packageManifest.name });
+const groupName = xcodeProjectDirectory.replace('.xcodeproj', '');
+const projectGroup = project.findPBXGroupKey({ name: groupName });
 project.addSourceFile(
     pathToAppdelegateExtension,
     { target: project.getFirstTarget().uuid },

--- a/scripts/postunlink.js
+++ b/scripts/postunlink.js
@@ -8,14 +8,15 @@ const helpers = require('./xcode-helpers');
 
 const projectDirectory = process.cwd();
 const moduleDirectory = path.resolve(__dirname, '..');
-const packageManifest = require(projectDirectory + '/package.json');
+const sourceDirectory = path.join(projectDirectory, 'ios');
+const xcodeProjectDirectory = helpers.findProject(sourceDirectory);
 
 const projectConfig = {
-    sourceDir: path.join(projectDirectory, 'ios'),
+    sourceDir: sourceDirectory,
     pbxprojPath: path.join(
         projectDirectory,
         'ios',
-        packageManifest.name + '.xcodeproj',
+        xcodeProjectDirectory,
         'project.pbxproj'
     ),
 };
@@ -61,7 +62,8 @@ helpers.removeFromFrameworkSearchPaths(
 );
 
 // remove AppDelegate extension
-const projectGroup = project.findPBXGroupKey({ name: packageManifest.name });
+const groupName = xcodeProjectDirectory.replace('.xcodeproj', '');
+const projectGroup = project.findPBXGroupKey({ name: groupName });
 project.removeSourceFile(
     pathToAppdelegateExtension,
     { target: project.getFirstTarget().uuid },


### PR DESCRIPTION
Steps to reproduce the issue:
- Create a new react native project `react-native init BackgroundFetch`
- Add lib as dependency `npm install react-native-background-fetch --save` or `yarn add react-native-background-fetch`
- Change npm project name in `package.json` file from `BackgroundFetch` to `background-fetch`
- Attempt to link dependency: `react-native link react-native-background-fetch`
- Notice error messages and failure to link the library.

Steps to test PR:
- Repeat the above steps on this PR branch. The link step should succeed.