### PR TITLE
Recover from headless task attempting to start in foreground

### DIFF
--- a/android/src/main/java/com/transistorsoft/rnbackgroundfetch/HeadlessTask.java
+++ b/android/src/main/java/com/transistorsoft/rnbackgroundfetch/HeadlessTask.java
@@ -89,11 +89,17 @@ public class HeadlessTask implements HeadlessJsTaskEventListener {
         final HeadlessJsTaskContext headlessJsTaskContext = HeadlessJsTaskContext.getInstance(reactContext);
         headlessJsTaskContext.addTaskEventListener(this);
         mActiveTaskContext = headlessJsTaskContext;
-        UiThreadUtil.runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                int taskId = headlessJsTaskContext.startTask(taskConfig);
-            }
-        });
+        try {
+            UiThreadUtil.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    int taskId = headlessJsTaskContext.startTask(taskConfig);
+                }
+            });
+        } catch (IllegalStateException exception) {
+            Log.e(BackgroundFetch.TAG, "Headless task attempted to run in the foreground.  Task ignored.");
+            return;  // <-- Do nothing.  Just return
+        }
+
     }
 }


### PR DESCRIPTION
fix for #118: if headless task is attempted to start while app is in foreground, swallow the exception