### PR TITLE
Double check that app isn't in foreground before executing headless task

### DIFF
--- a/android/src/main/java/com/transistorsoft/rnbackgroundfetch/HeadlessTask.java
+++ b/android/src/main/java/com/transistorsoft/rnbackgroundfetch/HeadlessTask.java
@@ -14,6 +14,7 @@ import com.facebook.react.jstasks.HeadlessJsTaskConfig;
 import com.facebook.react.jstasks.HeadlessJsTaskContext;
 import com.facebook.react.jstasks.HeadlessJsTaskEventListener;
 import com.transistorsoft.tsbackgroundfetch.BackgroundFetch;
+import com.facebook.react.common.LifecycleState;
 
 /**
  * Created by chris on 2018-01-17.
@@ -86,6 +87,9 @@ public class HeadlessTask implements HeadlessJsTaskEventListener {
     }
 
     private void invokeStartTask(ReactContext reactContext, final HeadlessJsTaskConfig taskConfig) {
+        if (reactContext.getLifecycleState() == LifecycleState.RESUMED) {
+            return;
+        }
         final HeadlessJsTaskContext headlessJsTaskContext = HeadlessJsTaskContext.getInstance(reactContext);
         headlessJsTaskContext.addTaskEventListener(this);
         mActiveTaskContext = headlessJsTaskContext;


### PR DESCRIPTION
Additional protection for https://github.com/transistorsoft/react-native-background-fetch/issues/118
For some reason https://github.com/transistorsoft/react-native-background-fetch/pull/123 wasn't catching all of the crashes related to this, but the current PR prevents nearly all of them of them