### PR TITLE
[RELEASE] 2.5.3 with improved react-native link script for Android. …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [2.5.3]
+- [Added] Added android implementation for `react-native link` script to automatically add the required `maven url`.  No more extras steps required -- simply:  `react-native link react-native-background-fetch`.
+
 ## [2.5.2] -- 2019-04-10
 - [Fixed] Fixed `react-native link` scripts to detect when installing into an app already configured for Cocoapods.
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,11 @@ The Android plugin provides a [HeadlessJS](https://facebook.github.io/react-nati
 
 ```bash
 $ yarn add react-native-background-fetch
-
-$ react-native link react-native-background-fetch
 ```
 
 ### With `npm`
 ```bash
 $ npm install --save react-native-background-fetch
-
-$ react-native link react-native-background-fetch
 ```
 
 ## iOS Setup

--- a/docs/INSTALL-LINK-ANDROID.md
+++ b/docs/INSTALL-LINK-ANDROID.md
@@ -1,5 +1,7 @@
 # Android `react-native link` Installation
 
+No manual steps required.
+
 ### With `yarn`
 
 ```bash
@@ -15,25 +17,3 @@ $ npm install --save react-native-background-fetch
 ```bash
 $ react-native link react-native-background-fetch
 ```
-
-### Gradle Configuration
-
-#### :open_file_folder: **`android/build.gradle`**
-
-```diff
-allprojects {
-    repositories {
-        mavenLocal()
-        google()
-        jcenter()
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "$rootDir/../node_modules/react-native/android"
-        }
-+       maven {
-+           url "$rootDir/../node_modules/react-native-background-fetch/android/libs"
-+       }
-    }
-}
-```
-

--- a/docs/INSTALL-MANUAL-ANDROID.md
+++ b/docs/INSTALL-MANUAL-ANDROID.md
@@ -4,8 +4,6 @@
 
 ```bash
 $ yarn add react-native-background-fetch
-
-$ react-native link react-native-background-fetch
 ```
 
 ## With `npm`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-fetch",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "iOS & Android BackgroundFetch API implementation for React Native",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/scripts/postunlink.js
+++ b/scripts/postunlink.js
@@ -101,3 +101,29 @@ if (Array.isArray(plist.UIBackgroundModes)) {
 
 helpers.writePlist(projectConfig.sourceDir, project, plist);
 fs.writeFileSync(projectConfig.pbxprojPath, project.writeSync());
+
+////
+// Android
+// - Remove maven url
+//     maven {
+//         url "$rootDir/../node_modules/react-native-background-geolocation/android/libs"
+//     }
+//
+const androidSrcDir = path.join(projectDirectory, 'android');
+const gradleFile = path.join(androidSrcDir, 'build.gradle');
+const moduleName = moduleDirectory.split('/').pop();
+
+fs.readFile(gradleFile, 'utf8', function (err,data) {
+  if (err) {
+    return console.log(err);
+  }
+  var re = new RegExp("[\\t?\\s?]+maven\\s?\\{[\\n?\\s?\\t?]+url.*" + moduleName + "\\/.*[\\n?\\t?\\s?]+\\}", "gm");
+
+  if (data.match(re)) {
+      fs.writeFile(gradleFile, data.replace(re, ''), 'utf8', function (err) {
+         if (err) return console.log(err);
+      });
+  }
+
+});
+


### PR DESCRIPTION
No more manual steps required (ie: `maven { url ...}`).  The plugin's `react-native link` script will automatically write to `android/build.gradle` to add the required `maven url`.

Simply:
```
$ react-native link react-native-background-fetch`
```
done.