### PR TITLE
types: update headless callback in example to match types

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Set `true` to enable React Native's [Headless JS](https://facebook.github.io/rea
 ```javascript
 import BackgroundFetch from "react-native-background-fetch";
 
-let MyHeadlessTask = async (event) => {
+let MyHeadlessTask = async () => {
   console.log('[BackgroundFetch HeadlessTask] start');
 
   // Perform an example HTTP request.


### PR DESCRIPTION
In my configuration of Visual Studio Code at least, a cut-n-paste of the example fails typescript type analysis because the published typing of the argument to registerHeadlessTask is `() => void`

When I look at the javascript implementation in index.js, it seems to match the `() => void` typing