### PR TITLE
Wrap new tread in try/catch

### DIFF
--- a/android/src/main/java/com/transistorsoft/rnbackgroundfetch/HeadlessTask.java
+++ b/android/src/main/java/com/transistorsoft/rnbackgroundfetch/HeadlessTask.java
@@ -97,7 +97,12 @@ public class HeadlessTask implements HeadlessJsTaskEventListener {
             UiThreadUtil.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    int taskId = headlessJsTaskContext.startTask(taskConfig);
+                    try {
+                        int taskId = headlessJsTaskContext.startTask(taskConfig);
+                    } catch (IllegalStateException exception) {
+                        Log.e(BackgroundFetch.TAG, "Headless task attempted to run in the foreground.  Task ignored.");
+                        return;  // <-- Do nothing.  Just return
+                    }
                 }
             });
         } catch (IllegalStateException exception) {

--- a/docs/INSTALL-LINK-ANDROID.md
+++ b/docs/INSTALL-LINK-ANDROID.md
@@ -14,16 +14,12 @@ $ react-native link react-native-background-fetch
 allprojects {
     repositories {
         mavenLocal()
+        google()
         jcenter()        
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
-        // For latest Google Apis
-+       maven {
-+           url 'https://maven.google.com'
-+       }
-
 +       maven {
 +           url "$rootDir/../node_modules/react-native-background-fetch/android/libs"
 +       }


### PR DESCRIPTION
Because `headlessJsTaskContext.startTask` is run in a new thread we need to wrap it in its own `try`. Also some more catches for exceptions we've seen in production