### PR TITLE
Removed /libs on docs/INSTALL-MANUAL-ANDROID.md maven url

### DIFF
--- a/docs/INSTALL-MANUAL-ANDROID.md
+++ b/docs/INSTALL-MANUAL-ANDROID.md
@@ -36,7 +36,7 @@ allprojects {
             url "$rootDir/../node_modules/react-native/android"
         }
 +       maven {
-+           url "$rootDir/../node_modules/react-native-background-fetch/android/libs"
++           url "$rootDir/../node_modules/react-native-background-fetch/android"
 +       }
     }
 }


### PR DESCRIPTION
url "$rootDir/../node_modules/react-native-background-fetch/android/libs" causes an import error on MainApplication.java end. Used url "$rootDir/../node_modules/react-native-background-fetch/android" instead.