### PR TITLE
Bg task scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * [Fixed] iOS - Missing native implementation for method scheduleTask.
 * [Changed] Bumped 2.8.0 to 3.0.0 to better flag this version for breaking changes.
 
-## [2.8.0] &mdash; 2020-02-10
 * [Added] [Android] New option `forceAlarmManager` for bypassing `JobScheduler` mechanism in favour of `AlarmManager` for more precise scheduling task execution.
 * [Changed] Migrate iOS deprecated "background-fetch" API to new [BGTaskScheduler](https://developer.apple.com/documentation/backgroundtasks/bgtaskscheduler?language=objc).  See new required steps in iOS Setup.
 * [Added] Added new `BackgroundFetch.scheduleTask` method for scheduling custom "onehot" and periodic tasks in addition to the default fetch-task.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [3.0.0] &mdash; 2020-02-17
+* [Fixed] Android - Incorrect event signature for method stop (not receiving success, failure callbacks)
+* [Fixed] iOS - Missing native implementation for method scheduleTask.
+* [Changed] Bumped 2.8.0 to 3.0.0 to better flag this version for breaking changes.
+
 ## [2.8.0] &mdash; 2020-02-10
 * [Added] [Android] New option `forceAlarmManager` for bypassing `JobScheduler` mechanism in favour of `AlarmManager` for more precise scheduling task execution.
 * [Changed] Migrate iOS deprecated "background-fetch" API to new [BGTaskScheduler](https://developer.apple.com/documentation/backgroundtasks/bgtaskscheduler?language=objc).  See new required steps in iOS Setup.

--- a/README.md
+++ b/README.md
@@ -279,7 +279,26 @@ This state is a loose definition provided by the system. In general, it means th
 
 ### iOS
 
-- Simulate background fetch events in XCode using **`Debug->Simulate Background Fetch`** (_Note:_ You are FORCING a background fetch to be run. This will run the `successFn` even if the `#stop` method has been called. In practice, iOS won't fire fetch events after you've called `#stop`)
+#### New `BGTaskScheduler` API for iOS 13+
+- The old command *Debug->Simulate Background Fetch* no longer works with new `BGTaskSCheduler` API.
+- At the time of writing, the new task simulator does not yet work in Simulator; Only real devices.
+- See Apple docs [Starting and Terminating Tasks During Development](https://developer.apple.com/documentation/backgroundtasks/starting_and_terminating_tasks_during_development?language=objc)
+- After running your app in XCode, Click the `[||]` button to initiate a *Breakpoint*.
+
+![](https://dl.dropboxusercontent.com/s/zr7w3g8ivf71u32/ios-simulate-bgtask-pause.png?dl=1)
+
+- In the console `(lldb)`, paste the following command (**Note:**  use cursor up/down keys to cycle through previously run commands):
+```obj-c
+e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.transistorsoft.fetch"]
+```
+![](https://dl.dropboxusercontent.com/s/87c9uctr1ka3s1e/ios-simulate-bgtask-paste.png?dl=1)
+
+- Click the `[ > ]` button to continue.  The task will execute and the Callback function provided to **`BackgroundFetch.configure`** will receive the event.
+
+![](https://dl.dropboxusercontent.com/s/bsv0avap5c2h7ed/ios-simulate-bgtask-play.png?dl=1)
+
+#### Old `BackgroundFetch` API
+- Simulate background fetch events in XCode using **`Debug->Simulate Background Fetch`**
 - iOS can take some hours or even days to start a consistently scheduling background-fetch events since iOS schedules fetch events based upon the user's patterns of activity.  If *Simulate Background Fetch* works, your can be **sure** that everything is working fine.  You just need to wait.
 
 ### Android

--- a/android/src/main/java/com/transistorsoft/rnbackgroundfetch/RNBackgroundFetchModule.java
+++ b/android/src/main/java/com/transistorsoft/rnbackgroundfetch/RNBackgroundFetchModule.java
@@ -63,10 +63,11 @@ public class RNBackgroundFetchModule extends ReactContextBaseJavaModule implemen
     }
 
     @ReactMethod
-    public void stop(@Nullable String taskId) {
+    public void stop(@Nullable String taskId, Callback success, Callback failure) {
         if (taskId == null) taskId = FETCH_TASK_ID;
         BackgroundFetch adapter = getAdapter();
         adapter.stop(taskId);
+        success.invoke(true);
     }
 
     @ReactMethod

--- a/ios/RNBackgroundFetch/RNBackgroundFetch.m
+++ b/ios/RNBackgroundFetch/RNBackgroundFetch.m
@@ -93,6 +93,23 @@ RCT_EXPORT_METHOD(stop:(NSString*)taskId success:(RCTResponseSenderBlock)success
     success(@[@(YES)]);
 }
 
+RCT_EXPORT_METHOD(scheduleTask:(NSDictionary*)config success:(RCTResponseSenderBlock)success failure:(RCTResponseSenderBlock)failure) {
+    NSString *taskId = [config objectForKey:@"taskId"];
+    long delayMS = [[config objectForKey:@"delay"] longValue];
+    NSTimeInterval delay = delayMS / 1000;
+    BOOL periodic = [[config objectForKey:@"periodic"] boolValue];
+
+    NSError *error = [[TSBackgroundFetch sharedInstance] scheduleProcessingTaskWithIdentifier:taskId
+                                                                                        delay:delay
+                                                                                     periodic:periodic
+                                                                                     callback:[self createCallback]];
+    if (!error) {
+        success(@[@(YES)]);
+    } else {
+        failure(@[error.localizedDescription]);
+    }
+}
+
 RCT_EXPORT_METHOD(finish:(NSString*)taskId)
 {
     TSBackgroundFetch *fetchManager = [TSBackgroundFetch sharedInstance];
@@ -109,7 +126,7 @@ RCT_EXPORT_METHOD(status:(RCTResponseSenderBlock)callback)
 -(void (^)(NSString* taskId)) createCallback {
     return ^void(NSString* taskId){
         RCTLogInfo(@"- %@ Rx Fetch Event", RN_BACKGROUND_FETCH_TAG);
-        [self sendEventWithName:EVENT_FETCH body:PLUGIN_ID];
+        [self sendEventWithName:EVENT_FETCH body:taskId];
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-fetch",
-  "version": "2.8.0",
+  "version": "3.0.0",
   "description": "iOS & Android BackgroundFetch API implementation for React Native",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
* [Fixed] Android - Incorrect event signature for method `#stop` (not receiving success, failure callbacks)
* [Fixed] iOS - Missing native implementation for method `scheduleTask`.
* [Changed] Bumped `2.8.0` to `3.0.0` to better flag this version for breaking changes (thanks @mikehardy )