### PR TITLE
suggestion: api changes

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -14,7 +14,15 @@ import {
   ScrollView,
   StatusBar,
 } from 'react-native';
-import BackgroundFetch, { BackgroundFetchStatus } from 'react-native-background-fetch';
+import {
+  BackgroundFetchStatus,
+  configure,
+  finish,
+  NETWORK_TYPE_NONE as requiredNetworkType,
+  scheduleTask as scheduleBGTask,
+  start,
+  stop,
+} from 'react-native-background-fetch';
 
 import { Event } from './types';
 import {
@@ -41,7 +49,7 @@ type IProps = {
 
 export const scheduleTask = async (name: string) => {
   try {
-    await BackgroundFetch.scheduleTask({
+    await scheduleBGTask({
       taskId: name,
       delay: 5000,       // milliseconds
       forceAlarmManager: true,
@@ -64,9 +72,9 @@ const App: FC<IProps> = (props: IProps) => {
   const onToggleEnabled = async (value:boolean) => {
     try {
       if (value) {
-        await BackgroundFetch.start();
+        await start();
       } else {
-        await BackgroundFetch.stop();
+        await stop();
       }
       setEnabled(value);
     } catch (e) {
@@ -95,14 +103,14 @@ const App: FC<IProps> = (props: IProps) => {
       // Required: Signal completion of your task to native code
       // If you fail to do this, the OS can terminate your app
       // or assign battery-blame for consuming too much background-time
-      BackgroundFetch.finish(taskId);
+      finish(taskId);
     } catch (e) {
       console.warn('[js] BackgroundFetch finish falied', e);
     }
   };
   const init = async () => {
     try {
-      BackgroundFetch.configure(
+      configure(
         {
           minimumFetchInterval: 15,     // <-- minutes (15 is minimum allowed)
           // Android options
@@ -110,7 +118,7 @@ const App: FC<IProps> = (props: IProps) => {
           stopOnTerminate: false,
           enableHeadless: true,
           startOnBoot: true,
-          requiredNetworkType: BackgroundFetch.NETWORK_TYPE_NONE, // Default
+          requiredNetworkType, // Default
           requiresCharging: false,      // Default
           requiresDeviceIdle: false,    // Default
           requiresBatteryNotLow: false, // Default

--- a/example/components/Footer.tsx
+++ b/example/components/Footer.tsx
@@ -5,7 +5,10 @@ import {
   View,
   Button,
 } from 'react-native';
-import BackgroundFetch, { BackgroundFetchStatus } from 'react-native-background-fetch';
+import {
+  BackgroundFetchStatus,
+  status as BGStatus,
+} from 'react-native-background-fetch';
 
 import { styles, status as getStatus } from '../utils';
 
@@ -17,7 +20,7 @@ type IProps = {
 const Footer: FC<IProps> = ({ clear, defaultStatus = 'unknown' }: IProps) => {
   const [currentStatus, setStatus] = useState(defaultStatus);
   const checkAccess = async () => {
-    const status: BackgroundFetchStatus = await BackgroundFetch.status();
+    const status: BackgroundFetchStatus = await BGStatus();
     status && setStatus(getStatus(status));
   };
 

--- a/example/index.js
+++ b/example/index.js
@@ -3,7 +3,11 @@
  */
 
 import { AppRegistry } from 'react-native';
-import BackgroundFetch from 'react-native-background-fetch';
+import {
+  finish,
+  onFetch,
+  registerHeadlessTask,
+} from 'react-native-background-fetch';
 
 import App from './App';
 import { name as appName } from './app.json';
@@ -33,12 +37,12 @@ const headlessTask = async ({ taskId }) => {
   // Required:  Signal to native code that your task is complete.
   // If you don't do this, your app could be terminated and/or assigned
   // battery-blame for consuming too much time in background.
-  BackgroundFetch.finish(taskId);
+  finish(taskId);
 };
 
 // Register your BackgroundFetch HeadlessTask
-BackgroundFetch.registerHeadlessTask(headlessTask);
+registerHeadlessTask(headlessTask);
 
-BackgroundFetch.onFetch(() => {
+onFetch(() => {
   console.info('[js] BackgroundFetch fetch');
 });

--- a/index.js
+++ b/index.js
@@ -4,112 +4,100 @@ import {
   NativeModules,
   NativeEventEmitter,
   AppRegistry
-} from "react-native";
+} from 'react-native';
 
 const RNBackgroundFetch = NativeModules.RNBackgroundFetch;
 const EventEmitter = new NativeEventEmitter(RNBackgroundFetch);
 
-const EVENT_FETCH = "fetch";
-const TAG         = "RNBackgroundFetch";
-const EVENTS      = ["fetch"];
+const EVENT_FETCH = 'fetch';
+const TAG         = 'RNBackgroundFetch';
+const EVENTS      = ['fetch'];
 
-const STATUS_RESTRICTED = 0;
-const STATUS_DENIED     = 1;
-const STATUS_AVAILABLE  = 2;
+export const STATUS_RESTRICTED = 0;
+export const STATUS_DENIED     = 1;
+export const STATUS_AVAILABLE  = 2;
 
-const NETWORK_TYPE_NONE         = 0;
-const NETWORK_TYPE_ANY          = 1;
-const NETWORK_TYPE_UNMETERED    = 2;
-const NETWORK_TYPE_NOT_ROAMING  = 3;
-const NETWORK_TYPE_CELLULAR     = 4;
+export const NETWORK_TYPE_NONE         = 0;
+export const NETWORK_TYPE_ANY          = 1;
+export const NETWORK_TYPE_UNMETERED    = 2;
+export const NETWORK_TYPE_NOT_ROAMING  = 3;
+export const NETWORK_TYPE_CELLULAR     = 4;
 
-export default class BackgroundFetch {
-  static get STATUS_RESTRICTED() { return STATUS_RESTRICTED; }
-  static get STATUS_DENIED() { return STATUS_DENIED; }
-  static get STATUS_AVAILABLE() { return STATUS_AVAILABLE; }
-
-  static get NETWORK_TYPE_NONE() { return NETWORK_TYPE_NONE; }
-  static get NETWORK_TYPE_ANY() { return NETWORK_TYPE_ANY; }
-  static get NETWORK_TYPE_UNMETERED() { return NETWORK_TYPE_UNMETERED; }
-  static get NETWORK_TYPE_NOT_ROAMING() { return NETWORK_TYPE_NOT_ROAMING; }
-  static get NETWORK_TYPE_CELLULAR() { return NETWORK_TYPE_CELLULAR; }
-
-  static configure(config, callback, failure) {
-    if (typeof(callback) !== 'function') {
-      throw "RNBackgroundFetch requires a fetch callback at 2nd argument";
-    }
-    EventEmitter.removeAllListeners('fetch');
-    config = config || {};
-    failure = failure || function() {};
-    RNBackgroundFetch.configure(config, failure);
-    return this.addListener(EVENT_FETCH, callback);
+export const addListener = (event, callback) => {
+  if (EVENTS.indexOf(event) < 0) {
+    throw new Error(`RNBackgroundFetch: Unknown event '${event}'`);
   }
+  return EventEmitter.addListener(event, callback);
+};
 
-  static scheduleTask(config) {
-    return new Promise((resolve, reject) => {
-      let success = (success) => { resolve(success) }
-      let failure = (error) => { reject(error) }
-      RNBackgroundFetch.scheduleTask(config, success, failure);
-    });
+export const configure = (config, callback, failure) => {
+  if (typeof(callback) !== 'function') {
+    throw new Error(`RNBackgroundFetch requires a fetch callback at 2nd argument`);
   }
+  EventEmitter.removeAllListeners('fetch');
+  config = config || {};
+  failure = failure || () => {};
+  RNBackgroundFetch.configure(config, failure);
+  return addListener(EVENT_FETCH, callback);
+};
 
-  /**
-  * Register HeadlessTask
-  */
-  static registerHeadlessTask(task) {
-    AppRegistry.registerHeadlessTask("BackgroundFetch", () => task);
-  }
+export const scheduleTask(config) => {
+  return new Promise((resolve, reject) => {
+    const success = success => resolve(success);
+    const failure = error => reject(error);
+    RNBackgroundFetch.scheduleTask(config, success, failure);
+  });
+};
 
-  static onFetch(callback) {
-    this.addListener('fetch', callback);
-  }
+/**
+* Register HeadlessTask
+*/
+export const registerHeadlessTask = (task) => {
+  AppRegistry.registerHeadlessTask('BackgroundFetch', () => task);
+};
 
-  static on(event, callback) {
-    return this.addListener(event, callback);
-  }
-
-  static addListener(event, callback) {
-    if (EVENTS.indexOf(event) < 0) {
-      throw "RNBackgroundFetch: Unknown event '" + event + '"';
-    }
-    return EventEmitter.addListener(event, callback);
-  }
-
-  static start() {
-    return new Promise((resolve, reject) => {
-      let success = (status) => {
-        resolve(status);
-      }
-      let failure = (error) => {
-        reject(error);
-      }
-      RNBackgroundFetch.start(success, failure);
-    })
-  }
-
-  static stop(taskId) {
-    return new Promise((resolve, reject) => {
-      let success = (success) => {
-        resolve(success);
-      }
-      let failure = (error) => {
-        reject(error);
-      }
-      RNBackgroundFetch.stop(taskId, success, failure);
-    });
-  }
-
-  static finish(taskId) {
-    RNBackgroundFetch.finish(taskId);
-  }
-
-  static status(callback) {
-    if (typeof(callback) === 'function') {
-      return RNBackgroundFetch.status(callback);
-    }
-    return new Promise((resolve, reject) => {
-      RNBackgroundFetch.status(resolve);
-    })
-  }
+export const onFetch = (callback) => {
+  addListener('fetch', callback);
 }
+
+export const on = (event, callback) => {
+  return addListener(event, callback);
+}
+
+export const start = () => {
+  return new Promise((resolve, reject) => {
+    let success = (status) => {
+      resolve(status);
+    }
+    let failure = (error) => {
+      reject(error);
+    }
+    RNBackgroundFetch.start(success, failure);
+  })
+};
+
+export const stop = (taskId) => {
+  return new Promise((resolve, reject) => {
+    let success = (success) => {
+      resolve(success);
+    }
+    let failure = (error) => {
+      reject(error);
+    }
+    RNBackgroundFetch.stop(taskId, success, failure);
+  });
+};
+
+export const finish = (taskId) => {
+  RNBackgroundFetch.finish(taskId);
+};
+
+export const status = (callback) => {
+  if (typeof callback === 'function') {
+    return RNBackgroundFetch.status(callback);
+  }
+  return new Promise((resolve, reject) => {
+    RNBackgroundFetch.status(resolve);
+  })
+};
 


### PR DESCRIPTION
in few words: replace `static` methods of `class` with `export` for each method

options to import

## I 
```
import * as BackgroundFetch, { BackgroundFetchStatus } from 'react-native-background-fetch';
```

## II

```
import {
  BackgroundFetchStatus,
  configure,
  finish,
  NETWORK_TYPE_NONE,
  scheduleTask as scheduleBGTask,
  start,
  stop,
} from 'react-native-background-fetch';
```
