### PR TITLE
[RELEASE] 3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## [3.0.5] &mdash; 2020-05-13
+* [Fixed] Remove an unnecessary reference to `androidx` to allow the plugin to work with non-androidX for those using RN `<=0.59`.
+* [Added] Update *Android Setup* with new required `proguard-rules.pro` for those building release with `minifyEnabled true`.  Fixes #261.
+
+1.  Edit `android/app/proguard-rules.pro`.
+2.  Add the following rule:
+
+```bash
+# [react-native-background-fetch]
+-keep class com.transistorsoft.rnbackgroundfetch.HeadlessTask { *; }
+```
+
 ## [3.0.4] &mdash; 2020-03-24
 * [Fixed] [iOS] Fixed bug calling `start` after executing `stop`.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ npm install --save react-native-background-fetch
 ## Android Setup
 
 ### `react-native >= 0.60`
-- No other steps required.
+- [Auto-linking Setup](docs/INSTALL-AUTO-ANDROID.md)
 
 ### `react-native < 0.60`
 - [`react-native link` Setup](docs/INSTALL-LINK-ANDROID.md)

--- a/android/src/main/java/com/transistorsoft/rnbackgroundfetch/RNBackgroundFetchModule.java
+++ b/android/src/main/java/com/transistorsoft/rnbackgroundfetch/RNBackgroundFetchModule.java
@@ -3,8 +3,6 @@ package com.transistorsoft.rnbackgroundfetch;
 import android.app.Activity;
 import android.content.Intent;
 
-import androidx.annotation.Nullable;
-
 import com.facebook.react.bridge.*;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
 import com.transistorsoft.tsbackgroundfetch.BackgroundFetch;
@@ -63,7 +61,7 @@ public class RNBackgroundFetchModule extends ReactContextBaseJavaModule implemen
     }
 
     @ReactMethod
-    public void stop(@Nullable String taskId, Callback success, Callback failure) {
+    public void stop(String taskId, Callback success, Callback failure) {
         if (taskId == null) taskId = FETCH_TASK_ID;
         BackgroundFetch adapter = getAdapter();
         adapter.stop(taskId);

--- a/docs/INSTALL-AUTO-ANDROID.md
+++ b/docs/INSTALL-AUTO-ANDROID.md
@@ -1,0 +1,27 @@
+# Android Auto-linking Setup
+
+### `react-native >= 0.60`
+
+### With `yarn`
+
+```bash
+$ yarn add react-native-background-fetch
+```
+
+### With `npm`
+```bash
+$ npm install --save react-native-background-fetch
+```
+
+## Configure __`proguard-rules.pro`__
+
+If you're using __`minifyEnabled true`__ with your Android release build, the plugin's __`HeadlessTask`__ class will be mistakenly *removed* and you will have [this crash](https://github.com/transistorsoft/react-native-background-fetch/issues/261).
+
+1.  Edit `android/app/proguard-rules.pro`.
+2.  Add the following rule:
+
+```bash
+# [react-native-background-fetch]
+-keep class com.transistorsoft.rnbackgroundfetch.HeadlessTask { *; }
+```
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-fetch",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "iOS & Android BackgroundFetch API implementation for React Native",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## [3.0.5] &mdash; 2020-05-13
* [Fixed] Remove an unnecessary reference to `androidx` to allow the plugin to work with non-androidX for those using RN `<=0.59`.
* [Added] Update *Android Setup* with new required `proguard-rules.pro` for those building release with `minifyEnabled true`.  Fixes #261.

1.  Edit `android/app/proguard-rules.pro`.
2.  Add the following rule:

```bash
# [react-native-background-fetch]
-keep class com.transistorsoft.rnbackgroundfetch.HeadlessTask { *; }
```