### PR TITLE
[Fixed][Xcode] Direct dependency on React-Core in podspec

### DIFF
--- a/RNBackgroundFetch.podspec
+++ b/RNBackgroundFetch.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.requires_arc        = true
   s.platform            = :ios, '8.0'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.preserve_paths      = 'docs', 'CHANGELOG.md', 'LICENSE', 'package.json', 'RNBackgroundFetch.ios.js'
   s.source_files        = 'ios/RNBackgroundFetch/RNBackgroundFetch.h', 'ios/RNBackgroundFetch/RNBackgroundFetch.m'
   s.vendored_frameworks = 'ios/RNBackgroundFetch/TSBackgroundFetch.framework'


### PR DESCRIPTION
React is an umbrella podspec and React-Core is what iOS native modules actually want.
This did not used to matter but in the Xcode 12 build system there is something racy that causes
builds to fail sometimes if the dependency is transitive vs direct

Reference: https://github.com/facebook/react-native/issues/29633