### PR TITLE
[RELEASE] 4.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [4.0.5] &mdash; 2022-02-10
+* [Fixed][iOS] Remove obsolete `__has_include("RCTEventEmitter.h")` code which was breaking Expo apps.
+
 ## [4.0.4] &mdash; 2021-10-22
 * [Fixed] EventEmitter warning about `addListener` / `removeListeners`
 * [Changed] Re-generate /example app with `react-native init`.  Complete re-factor to use React Hooks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-fetch",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "iOS & Android BackgroundFetch API implementation for React Native",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## [4.0.5] &mdash; 2022-02-10
* [Fixed][iOS] Remove obsolete `__has_include("RCTEventEmitter.h")` code which was breaking Expo apps.

https://github.com/transistorsoft/react-native-background-fetch/pull/377
