### PR TITLE
improve instructions for others to run example

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -13,6 +13,8 @@ $ yarn install
 $ cd ios
 $ pod install
 
+# Edit the ios/FetchDemo.xcodeproj/project.pbxproj file and set both lines with DEVELOPMENT_TEAM to your own Team ID. This can be found at https://developer.apple.com/account under Membership.
+
 $ npx react-native run-android
 $ npx react-native run-ios
 ```


### PR DESCRIPTION
Current code fails to build, with the message: `No account for team "32A636YFGZ". Add a new account in the Accounts preference pane or verify that your accounts have valid credentials.`

This prompt will help others build successfully.