### PR TITLE
[RELEASE] 4.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [4.1.6] &mdash; 2022-12-15
+* `TaskConfig.requiresNetworkConnectivity` was missing from typescript API.
+
 ## [4.1.5] &mdash; 2022-10-25
 * Remove `peerDependencies`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-fetch",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "iOS & Android BackgroundFetch API implementation for React Native",
   "scripts": {
     "build": "yarn run build:expo",


### PR DESCRIPTION
## [4.1.6] &mdash; 2022-12-15
* `TaskConfig.requiresNetworkConnectivity` was missing from typescript API.
