### PR TITLE
types: update registerHeadlessTask type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -180,6 +180,6 @@ declare module "react-native-background-fetch" {
 		/**
 		* [Android only] Register a function to execute when the app is terminated.  Requires stopOnTerminate: false.
 		*/
-		static registerHeadlessTask(task:(event:HeadlessEvent) => void):void;
+		static registerHeadlessTask(task:(event:HeadlessEvent) => Promise<void>):void;
 	}
 }


### PR DESCRIPTION
When the callback returns something other than a Promise, a "TypeError: Cannot read property 'then' of undefined, js engine: hermes" error is thrown.
