### PR TITLE
[Expo][iOS] Fix Swift AppDelegate plugin for @main annotation (Expo SDK 55+)

### DIFF
--- a/expo/plugin/src/iOSPlugin.ts
+++ b/expo/plugin/src/iOSPlugin.ts
@@ -66,7 +66,7 @@ const modifySwiftAppDelegate = (src:string) => {
     tag: "react-native-background-fetch-import",
     src,
     newSrc: "import TSBackgroundFetch",
-    anchor: /@UIApplicationMain/,
+    anchor: /@(UIApplication)?main/,
     offset: -1,
     comment: "//",
   }).contents;


### PR DESCRIPTION
## Summary

Expo SDK 55 adopted Swift 6, which changes the AppDelegate annotation from `@UIApplicationMain` to `@main`. The Expo config plugin in `iOSPlugin.ts` uses `/@UIApplicationMain/` as a regex anchor to inject `import TSBackgroundFetch` — this fails on SDK 55+ because the anchor never matches, crashing the build.

**Fix:** Update the regex from `/@UIApplicationMain/` to `/@(UIApplication)?main/` so it matches both:
- `@UIApplicationMain` (Expo SDK 53–54)
- `@main` (Expo SDK 55+)

## Affected file

- `expo/plugin/src/iOSPlugin.ts` (line 69) — 1-line change

## Test plan

- Verified the regex matches both `@UIApplicationMain` and `@main`
- Tested `yarn build` compiles successfully
- Confirmed the config plugin correctly injects `import TSBackgroundFetch` into a Swift AppDelegate using `@main`